### PR TITLE
#23 Implement w2m-like calendar

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
+    "date-fns": "^2.16.1",
     "vue": "^3.0.0",
     "vue-cal": "^4.0.0",
     "vue-router": "^4.0.0-rc.1"

--- a/frontend/src/components/Calendar.vue
+++ b/frontend/src/components/Calendar.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="calendar">
+    <div class="times">
+      <header>Times</header>
+      <div class="time" v-for="time in times" :key="`calendar-${time}`">
+        {{ time }}
+      </div>
+    </div>
+    <div class="wrapper">
+      <CalendarDay
+        v-for="date in dateRange"
+        :key="date"
+        :date="date"
+        :times="times"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { eachDayOfInterval, getHours } from "date-fns";
+import { defineComponent, PropType } from "vue";
+
+import CalendarDay from "./CalendarDay.vue";
+import { Calendar } from "../types";
+
+const Interval = 30; // minutes
+const MinsInHour = 60;
+
+const formatHour = (hour: number, minutes: number) => {
+  let formattedMinutes = String(minutes);
+  if (minutes < 10) {
+    formattedMinutes = `0${minutes}`;
+  }
+  return `${hour}:${formattedMinutes}`;
+};
+
+export default defineComponent({
+  components: {
+    CalendarDay
+  },
+  props: {
+    calendar: {
+      type: Object as PropType<Calendar>,
+      required: true
+    },
+    startTime: {
+      type: String,
+      required: true
+    },
+    endTime: {
+      type: String,
+      required: true
+    }
+  },
+  computed: {
+    start(): Date {
+      return new Date(this.startTime);
+    },
+    end(): Date {
+      return new Date(this.endTime);
+    },
+    dateRange(): string[] {
+      return eachDayOfInterval({
+        start: this.start,
+        end: this.end
+      }).map(date => date.toISOString());
+    },
+    earliestTime(): number {
+      return getHours(this.start);
+    },
+    latestTime(): number {
+      return getHours(this.end);
+    },
+    times(): string[] {
+      const hours = [] as string[];
+      for (let hour = this.earliestTime; hour <= this.latestTime; hour++) {
+        for (let i = 0; i < MinsInHour / Interval; i++) {
+          hours.push(formatHour(hour, i * Interval));
+        }
+      }
+      return hours.slice(0, hours.length - 1);
+    }
+  }
+});
+</script>
+
+<style scoped>
+.calendar {
+  display: flex;
+  padding-left: 4rem;
+  padding-right: 4rem;
+  font-size: 12px;
+}
+
+.times {
+  flex: 1;
+  text-align: right;
+  margin-right: 1rem;
+}
+
+.time {
+  height: 2em;
+  border: 0.5px solid transparent;
+}
+
+.wrapper {
+  display: flex;
+  flex: 12;
+  justify-content: space-between;
+}
+</style>

--- a/frontend/src/components/CalendarDay.vue
+++ b/frontend/src/components/CalendarDay.vue
@@ -1,7 +1,15 @@
 <template>
   <section class="day">
     <header>{{ dateText }}</header>
-    <div class="block" v-for="time in times" :key="`${dateText}-${time}`"></div>
+    <div
+      v-for="time in times"
+      :class="['block', { selected: selection.has(`${dateText}-${time}`) }]"
+      :key="`${dateText}-${time}`"
+      :data-time="`${dateText}-${time}`"
+      @mousedown="handleMouseDown"
+      @mouseover="handleMouseOver"
+      @mouseup="handleMouseUp"
+    ></div>
   </section>
 </template>
 
@@ -20,9 +28,47 @@ export default defineComponent({
       required: true
     }
   },
+  data() {
+    return {
+      dragging: false,
+      selection: new Set()
+    };
+  },
   computed: {
     dateText(): string {
       return format(new Date(this.date), "E MMM d");
+    }
+  },
+  mounted() {
+    window.addEventListener("mouseup", this.handleMouseUp);
+  },
+  beforeUnmount() {
+    window.removeEventListener("mouseup", this.handleMouseUp);
+  },
+  methods: {
+    handleMouseOver(evt: MouseEvent) {
+      if (this.dragging) {
+        evt.preventDefault();
+        const el = evt.target as HTMLElement;
+        this.toggle(el.dataset.time);
+      }
+    },
+    handleMouseDown(evt: MouseEvent) {
+      evt.preventDefault();
+      this.dragging = true;
+      const el = evt.target as HTMLElement;
+      this.toggle(el.dataset.time);
+    },
+    handleMouseUp(evt: MouseEvent) {
+      evt.preventDefault();
+      this.dragging = false;
+    },
+    toggle(key: string | undefined) {
+      if (this.selection.has(key)) {
+        this.selection.delete(key);
+      } else if (key) {
+        this.selection.add(key);
+      }
     }
   }
 });
@@ -36,5 +82,9 @@ export default defineComponent({
 .block {
   border: 0.5px solid lightgray;
   height: 2em;
+}
+
+.selected {
+  background: green;
 }
 </style>

--- a/frontend/src/components/CalendarDay.vue
+++ b/frontend/src/components/CalendarDay.vue
@@ -6,8 +6,11 @@
       :class="['block', { selected: selection.has(`${dateText}-${time}`) }]"
       :key="`${dateText}-${time}`"
       :data-time="`${dateText}-${time}`"
+      @touchstart="handleMouseDown"
       @mousedown="handleMouseDown"
+      @touchmove="handleMouseOver"
       @mouseover="handleMouseOver"
+      @touchend="handleMouseUp"
       @mouseup="handleMouseUp"
     ></div>
   </section>
@@ -40,26 +43,26 @@ export default defineComponent({
     }
   },
   mounted() {
-    window.addEventListener("mouseup", this.handleMouseUp);
+    window.addEventListener("touchstart", this.handleMouseUp);
   },
   beforeUnmount() {
-    window.removeEventListener("mouseup", this.handleMouseUp);
+    window.removeEventListener("touchend", this.handleMouseUp);
   },
   methods: {
-    handleMouseOver(evt: MouseEvent) {
+    handleMouseOver(evt: TouchEvent) {
       if (this.dragging) {
         evt.preventDefault();
         const el = evt.target as HTMLElement;
         this.toggle(el.dataset.time);
       }
     },
-    handleMouseDown(evt: MouseEvent) {
+    handleMouseDown(evt: TouchEvent) {
       evt.preventDefault();
       this.dragging = true;
       const el = evt.target as HTMLElement;
       this.toggle(el.dataset.time);
     },
-    handleMouseUp(evt: MouseEvent) {
+    handleMouseUp(evt: TouchEvent) {
       evt.preventDefault();
       this.dragging = false;
     },

--- a/frontend/src/components/CalendarDay.vue
+++ b/frontend/src/components/CalendarDay.vue
@@ -1,0 +1,40 @@
+<template>
+  <section class="day">
+    <header>{{ dateText }}</header>
+    <div class="block" v-for="time in times" :key="`${dateText}-${time}`"></div>
+  </section>
+</template>
+
+<script lang="ts">
+import { format } from "date-fns";
+import { defineComponent, PropType } from "vue";
+
+export default defineComponent({
+  props: {
+    date: {
+      type: String,
+      required: true
+    },
+    times: {
+      type: Object as PropType<Array<string>>,
+      required: true
+    }
+  },
+  computed: {
+    dateText(): string {
+      return format(new Date(this.date), "E MMM d");
+    }
+  }
+});
+</script>
+
+<style scoped>
+.day {
+  flex: 1;
+}
+
+.block {
+  border: 0.5px solid lightgray;
+  height: 2em;
+}
+</style>

--- a/frontend/src/components/TheNavbar.vue
+++ b/frontend/src/components/TheNavbar.vue
@@ -3,38 +3,22 @@
     <router-link
       class="router"
       v-for="link in links"
-      :key="link.to"
-      :to="link.to"
-      >{{ link.title }}
+      :key="link.path"
+      :to="link.path"
+      >{{ link.name }}
     </router-link>
   </nav>
 </template>
 
 <script>
-export default {
-  data() {
-    return {
-      links: [
-        {
-          title: "Home",
-          to: "/"
-        },
-        {
-          title: "About",
-          to: "/about"
-        },
-        {
-          title: "Counter",
-          to: "/counter"
-        },
-        {
-          title: "Calendar",
-          to: "/calendar"
-        }
-      ]
-    };
+import { defineComponent } from "vue";
+import { routes } from "../router";
+
+export default defineComponent({
+  setup() {
+    return { links: routes };
   }
-};
+});
 </script>
 
 <style scoped>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,7 +1,7 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
 import Home from "../views/Home.vue";
 
-const routes: Array<RouteRecordRaw> = [
+export const routes: Array<RouteRecordRaw> = [
   {
     path: "/",
     name: "Home",
@@ -22,9 +22,9 @@ const routes: Array<RouteRecordRaw> = [
     component: () => import("../components/Counter.vue")
   },
   {
-    path: "/calendar",
-    name: "Calendar",
-    component: () => import("../components/CalendarDisplay.vue")
+    path: "/event",
+    name: "Event",
+    component: () => import("../views/Event.vue")
   }
 ];
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -28,3 +28,8 @@ export interface Event {
   link: string;
   calendar: Calendar;
 }
+
+export interface Time {
+  hour: number;
+  minutes: number;
+}

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,16 @@
+import { getHours, getMinutes } from "date-fns";
+
+export const formatHour = (hour: number, minutes: number) => {
+  let formattedMinutes = String(minutes);
+  if (minutes < 10) {
+    formattedMinutes = `0${minutes}`;
+  }
+  return `${hour}:${formattedMinutes}`;
+};
+
+export const toTime = (date: Date) => {
+  return {
+    hour: getHours(date),
+    minutes: getMinutes(date)
+  };
+};

--- a/frontend/src/views/Event.vue
+++ b/frontend/src/views/Event.vue
@@ -1,15 +1,11 @@
 <template>
-  <Calendar :calendar="calendar" :startTime="start" :endTime="end" />
+  <Calendar v-model:calendar="calendar" :startTime="start" :endTime="end" />
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, reactive } from "vue";
 import Calendar from "../components/Calendar.vue";
 import { Calendar as ICalendar } from "../types";
-
-const mockCalendar: ICalendar = {
-  blocks: []
-};
 
 const end = new Date("October 8, 2020 21:00:00");
 const start = new Date("October 1, 2020 09:00:00");
@@ -19,10 +15,13 @@ export default defineComponent({
     Calendar
   },
   setup() {
+    const calendar = reactive<ICalendar>({
+      blocks: []
+    });
     return {
-      calendar: mockCalendar,
       start: start.toISOString(),
-      end: end.toISOString()
+      end: end.toISOString(),
+      calendar
     };
   }
 });

--- a/frontend/src/views/Event.vue
+++ b/frontend/src/views/Event.vue
@@ -1,0 +1,29 @@
+<template>
+  <Calendar :calendar="calendar" :startTime="start" :endTime="end" />
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import Calendar from "../components/Calendar.vue";
+import { Calendar as ICalendar } from "../types";
+
+const mockCalendar: ICalendar = {
+  blocks: []
+};
+
+const end = new Date("October 8, 2020 21:00:00");
+const start = new Date("October 1, 2020 09:00:00");
+
+export default defineComponent({
+  components: {
+    Calendar
+  },
+  setup() {
+    return {
+      calendar: mockCalendar,
+      start: start.toISOString(),
+      end: end.toISOString()
+    };
+  }
+});
+</script>

--- a/frontend/src/views/Event.vue
+++ b/frontend/src/views/Event.vue
@@ -3,9 +3,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive } from "vue";
+import { defineComponent } from "vue";
 import Calendar from "../components/Calendar.vue";
-import { Calendar as ICalendar } from "../types";
 
 const end = new Date("October 8, 2020 21:00:00");
 const start = new Date("October 1, 2020 09:00:00");
@@ -14,15 +13,20 @@ export default defineComponent({
   components: {
     Calendar
   },
-  setup() {
-    const calendar = reactive<ICalendar>({
-      blocks: []
-    });
+  data() {
     return {
-      start: start.toISOString(),
-      end: end.toISOString(),
-      calendar
+      calendar: {
+        blocks: []
+      }
     };
+  },
+  computed: {
+    start() {
+      return start.toISOString();
+    },
+    end() {
+      return end.toISOString();
+    }
   }
 });
 </script>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3230,6 +3230,11 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
+date-fns@^2.16.1:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## Overview ⚙️

> Provide a brief description of what this PR is for.

This PR implements a working when2meet-like calendar component. It introduces a new component `Calendar` that accepts three props:

- `calendar` - The calendar model described in week 4's meeting
  - Can be used with [v-model](https://v3.vuejs.org/guide/migration/v-model.html)
- `startTime` - The start date for the calendar view. Should be the **earliest possible** e.g. if the calendar's date range is M-F 9am-9pm, the start date should be Monday 9am.
- `endTime` - The end date for the calendar view. Should be the **latest possible** e.g. if the calendar's date range is M-F 9am-9pm, the end date should be Friday 9pm.

Availabilities can be filled in by dragging your mouse over the cells. Also works with touch devices! (albeit you have to tap, not drag)

## Change Summary 🛠️ 

> Provide a bullet-point summary of the changes that you made and why you made that change. For very small PRs you can skip this.

- `package.json` - Added [date-fns](https://date-fns.org/) as a dependency to easily manage date time manipulation.
- `Calendar.vue` - Component definition for the base `Calendar` component.
- `CalendarDay.vue` - Subcomponent used solely in the `Calendar` component. Responsible for the dragging logic and for rendering the cells for the given date and times.
  - This component doesn't manage its own state. It renders the blocks depending on those defined in the parent `Calendar` component. This keeps the `calendar` prop the single source of truth.
- `TheNavbar.vue` - Slight refactor here to minimize duplication and keep `routes` the source of truth.
- `routes/index.ts` - Change `calendar` page to an `event` page.
- `utils/time.ts` - Utility functions to handle `Time` objects.
- `views/Event.vue` - New page for demonstration purposes.

## Screenshots 👀 

> When relevant, provide a screenshot of the changes.

![lp-cal](https://user-images.githubusercontent.com/31267630/97949748-840a0780-1d49-11eb-838d-bc41fd720b10.gif)

## Other Notes 🗒️ 

The code is admittedly not super clean and some logic exists in places it probably shouldn't be in e.g. there's logic on comparing blocks in the `CalendarDay` component. We can probably look into implementing a better architecture a bit later.

## Related Issues ⚠️

> Put any issues that this PR addresses here. Make sure you use a [closing keyword](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) so GitHub knows to link the issue(s).

Closes #23