### PR TITLE
Add delete implementations

### DIFF
--- a/backend/data/clients/firebase/delete.go
+++ b/backend/data/clients/firebase/delete.go
@@ -1,11 +1,18 @@
 package firebase
 
+import (
+	"context"
+	log "github.com/sirupsen/logrus"
+)
+
 func (u *User) Delete() error {
-	// todo: implementation
-	return nil
+	log.Infof("Deleting user: %+v", u)
+	_, err := Client.Collection("users").Doc(u.FirebaseID).Delete(context.Background())
+	return err
 }
 
 func (e *Event) Delete() error {
-	// todo: implementation
-	return nil
+	log.Infof("Deleting user: %+v", e)
+	_, err := Client.Collection("events").Doc(e.FirebaseID).Delete(context.Background())
+	return err
 }

--- a/backend/data/clients/firebase/get.go
+++ b/backend/data/clients/firebase/get.go
@@ -24,10 +24,10 @@ func (u *User) Get() error {
 func (e *Event) Get() error {
 	// get document ref
 	id := e.FirebaseID
-	userDoc := Client.Collection("users").Doc(id)
+	eventDoc := Client.Collection("events").Doc(id)
 
 	// get document snapshot
-	snapshot, err := userDoc.Get(context.Background())
+	snapshot, err := eventDoc.Get(context.Background())
 	if err != nil {
 		return err
 	}

--- a/backend/data/clients/firebase/update.go
+++ b/backend/data/clients/firebase/update.go
@@ -1,11 +1,21 @@
 package firebase
 
-func (u *User) Update(documentID string) error {
-	// todo: implementation
-	return nil
+import (
+	"context"
+	log "github.com/sirupsen/logrus"
+)
+
+func (u *User) Update() error {
+	log.Infof("updating user in firestore: %+v", u)
+	id := u.FirebaseID
+	_, err := Client.Collection("users").Doc(id).Set(context.Background(),u)
+	return err
 }
 
-func (e *Event) Update(documentID string) error {
-	// todo: implementation
+func (e *Event) Update() error {
+	log.Infof("updating event in firestore: %+v", e)
+	id := e.FirebaseID
+	_, err := Client.Collection("users").Doc(id).Set(context.Background(),e)
+	return err
 	return nil
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -16,6 +16,8 @@ func main() {
 	// test route to add data to firestore
 	r.HandleFunc("/add", AddData).Methods("POST")
 	r.HandleFunc("/get/{id}", GetData).Methods("GET")
+	r.HandleFunc("/delete/{id}", DeleteData).Methods("DELETE")
+	r.HandleFunc("/update/{id}", UpdateUser).Methods("PATCH")
 
 	// serve on port 8080
 	log.Info("server started on 8080")

--- a/backend/test_firestore.go
+++ b/backend/test_firestore.go
@@ -52,3 +52,33 @@ func GetData(w http.ResponseWriter, r *http.Request) {
 	// marshal the data struct to JSON to send as response
 	json.NewEncoder(w).Encode(user)
 }
+
+func DeleteData(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	if vars["id"] == "" {
+		log.Fatal("no document id provided")
+	}
+	user := &firebase.User{FirebaseID: vars["id"]}
+	err := user.Delete()
+	if err != nil {
+		log.Fatalf("failed to delete user : %v", user)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+
+func UpdateUser(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	if vars["id"] == "" {
+		log.Fatal("no document id provided")
+	}
+	user := firebase.User{FirebaseID: vars["id"]}
+	err := json.NewDecoder(r.Body).Decode(&user)
+	log.Printf("user is liek this: %+v", user)
+	err = user.Update()
+	if err != nil {
+		log.Fatalf("failed to update user : %v", user)
+	}
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(user)
+}


### PR DESCRIPTION
Overview:
- Sends a 204 with no response body back 
- Verifies that the record with the specified ID is no longer stored at the end of execution. If the record has already been deleted, DELETE behaves in the same manner.
- We can pretty easily modify this behaviour, however due to the way firebase delete works, if we wanted to throw 404's for example we would have to do a get then delete.


Note
- Minor change to get.go (typo fix)