### PR TITLE
Add event CRUD endpoints

### DIFF
--- a/backend/data/schema/schema.go
+++ b/backend/data/schema/schema.go
@@ -17,8 +17,8 @@ type User struct {
 // Event describes a single event/meeting and includes.
 type Event struct {
 	FirebaseID string
-	Users      []User // who is in this event
-	Owners     []User // who owns this event
+	Users      []string // FirebaseID of users is in this event
+	Owners     []string // FirebaseID of event owners
 
 	// time window during which event can be scheduled
 	ScheduleWindow struct {

--- a/backend/main.go
+++ b/backend/main.go
@@ -14,10 +14,16 @@ func main() {
 	http.Handle("/", r)
 
 	// test route to add data to firestore
-	r.HandleFunc("/add", AddData).Methods("POST")
-	r.HandleFunc("/get/{id}", GetData).Methods("GET")
-	r.HandleFunc("/delete/{id}", DeleteData).Methods("DELETE")
-	r.HandleFunc("/update/{id}", UpdateUser).Methods("PATCH")
+	r.HandleFunc("/users", CreateUser).Methods("POST")
+	r.HandleFunc("/users/{id}", GetUser).Methods("GET")
+	r.HandleFunc("/users/{id}", DeleteUser).Methods("DELETE")
+	r.HandleFunc("/users/{id}", UpdateUser).Methods("PATCH")
+
+	//Event endpoints
+	r.HandleFunc("/events", CreateEvent).Methods("POST")
+	r.HandleFunc("/events/{id}", GetEvent).Methods("GET")
+	r.HandleFunc("/events/{id}", DeleteEvent).Methods("DELETE")
+	r.HandleFunc("/events/{id}", UpdateEvent).Methods("PATCH")
 
 	// serve on port 8080
 	log.Info("server started on 8080")


### PR DESCRIPTION
## Overview ⚙️
- CRUD for Events :) 

## Change Summary
- Expose Create, Read, Update, and Delete endpoints for events
**- Slightly changed the way errors are handled (at least for event endpoints to prevent the app crashing on 404, etc)**
- Modified User endpoints just to reflect event endpoints
- Modified events schema to store user ID strings

##Points for Discussion
- I'd like to come up with a policy that we can handle errors consistently
1) Send just the error codes or should we include a description to help them form a proper query (for example if they are missing a field or ID)
2) Do we want to fatally fail? I have use **Warn** instead for these endpoints.
3) Any other areas you guys suggest we standardize?

Based off of what we decide here I will change the rest of the endpoints for Users


## Related Issues ⚠️

https://github.com/ubclaunchpad/when3meet/issues/36

Closes #36
