### PR TITLE
Feature/set email as ref ID

### DIFF
--- a/backend/data/clients/firebase/write.go
+++ b/backend/data/clients/firebase/write.go
@@ -2,6 +2,7 @@ package firebase
 
 import (
 	"context"
+	"errors"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -9,10 +10,16 @@ import (
 func (u *User) Write() error {
 	// todo: consider logging ref or actual document info here
 	log.Infof("writing user to firestore: %+v", u)
+	// check if user with provided email already exists
+	ref, err := Client.Collection("users").Doc(u.Email).Get(context.Background())
+	if ref.Exists() {
+		log.Warnf("A user with this email already exists")
+		return errors.New("A user with this email already exists")
+	}
 
-	ref, _, err := Client.Collection("users").Add(context.Background(), u)
-	u.FirebaseID = ref.ID
-
+	// create a user with document ID set to email - this overwrites the document!
+	_, err = Client.Collection("users").Doc(u.Email).Set(context.Background(),u)
+	u.FirebaseID = u.Email
 	return err
 }
 

--- a/backend/data/schema/schema.go
+++ b/backend/data/schema/schema.go
@@ -8,9 +8,11 @@ import "time"
 // User describes a single when3meet user and includes their personal
 // availability calendar
 type User struct {
+	//TODO: Remove the FirebaseID field since it is the same as a user's email - for now we keep it since all our endpoints are using this
 	FirebaseID string
 	Username   string
 	Email      string
+	Events		[]string // FirebaseID of events that this user is attending or the owner of
 	Calendar   Calendar // default user calendar
 }
 

--- a/backend/data/schema/schema.go
+++ b/backend/data/schema/schema.go
@@ -8,7 +8,6 @@ import "time"
 // User describes a single when3meet user and includes their personal
 // availability calendar
 type User struct {
-	//TODO: Remove the FirebaseID field since it is the same as a user's email - for now we keep it since all our endpoints are using this
 	FirebaseID string
 	Username   string
 	Email      string

--- a/backend/test_firestore.go
+++ b/backend/test_firestore.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -27,7 +28,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 	err = user.Write()
 	if err != nil {
 		log.Warnf("Failed to add user : %v", err)
-		http.Error(w, "Something went wrong creating the user", http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("Something went wrong creating the user: %v",err), http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
## Overview ⚙️

Setting the Firebase document ref ID to the user's email. After more research I feel like we should actually go in a different direction, since I have a better understanding of firebase auth now. I feel like we should be using the User UID provided by firebase auth instead of the emails. Refer to the discussion section for more info.

This change
- Sets the user firebaseID to their email
- In each event, the ID of owners and users will be their email

##Discussion##
- Google Auth provides a User UID when you authenticate - should we be using this instead? We can explicitly set our document reference ID to the provided UID so I think this will address the problem that  we were talking about @gokcedilek  (Where the ID for schema is different from user). This makes more sense to me, but I don't have that much experience doing this stuff.

Thoughts?

<img width="937" alt="image" src="https://user-images.githubusercontent.com/35415298/99633190-597ba800-29f3-11eb-904d-031f8419a5cb.png">


Closes #1234
