### PR TITLE
Update event view page

### DIFF
--- a/frontend/src/components/AppToggleExternalText.vue
+++ b/frontend/src/components/AppToggleExternalText.vue
@@ -1,179 +1,123 @@
 <template>
   <label
-    :for="id + '_button'"
-    :class="{ active: isActive }"
-    class="toggle__button"
+    class="container"
+    :style="'--switch-container-width: 20rem'"
+    @click="update"
   >
-    <span class="toggle__label">{{ toggleLeftText }}</span>
-
     <input
+      v-bind="$attrs"
+      class="input"
       type="checkbox"
-      :disabled="disabled"
-      :id="id + '_button'"
-      v-model="checkedValue"
+      :checked="checked"
+      @change="$emit('update:checked', $event.target.checked)"
     />
-
-    <span class="toggle__switch"></span>
-
-    <span class="toggle__label">{{ toggleRightText }}</span>
+    <span class="switch"></span>
+    <span v-bind:class="{ leftWhite: !checked, left: checked }">{{
+      leftText
+    }}</span>
+    <span v-bind:class="{ right: !checked, rightWhite: checked }">{{
+      rightText
+    }}</span>
   </label>
 </template>
 
 <script>
 export default {
+  name: "Switch",
   props: {
-    /* Boolean dictates the disabled state of toggle */
-    disabled: {
+    leftText: {
+      type: String,
+      required: true
+    },
+    rightText: {
+      type: String,
+      required: true
+    },
+    checked: {
       type: Boolean,
-      default: false
-    },
-
-    /* Text of the false or left state */
-    toggleLeftText: {
-      type: String,
-      default: "«Left«"
-    },
-
-    /* Text of the false or right state */
-    toggleRightText: {
-      type: String,
-      default: "»Right»"
-    },
-
-    id: {
-      type: String,
-      default: "primary"
-    },
-
-    /* Default state of the toggle (false is left) */
-    defaultState: {
-      type: Boolean,
-      default: false
+      required: true
     }
   },
-
-  data() {
-    return {
-      currentToggleState: this.defaultState
-    };
-  },
-
-  watch: {
-    defaultState: function defaultState() {
-      this.currentToggleState = Boolean(this.defaultState);
-    }
-  },
-
-  computed: {
-    isActive() {
-      return this.currentToggleState;
-    },
-
-    /* Returns disabled / left text */
-    disabledText() {
-      return this.toggledLeftText;
-    },
-
-    /* Returns enabled / right text */
-    enabledText() {
-      return this.toggledRightText;
-    },
-
-    checkedValue: {
-      get() {
-        return this.currentToggleState;
-      },
-      set(newValue) {
-        this.currentToggleState = newValue;
-        this.$emit("change", newValue);
-      }
+  methods: {
+    update() {
+      this.$emit("update");
     }
   }
 };
 </script>
 
 <style scoped>
-/* TODO: Clean up styling */
-/* TODO: Grey out disabled toggle */
-/* TODO: Create constants for the accent colours for ease of modification */
-
-.toggle__label {
-  padding: 0 1rem;
-  font-size: 0.875em;
-}
-
-/* Hide Checkbox */
-.toggle__button input[type="checkbox"] {
-  display: none;
-}
-
-.toggle__button {
-  vertical-align: middle;
-  user-select: none;
+.container {
+  width: var(--switch-container-width);
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
-
-.toggle__button button[disabled] {
-  opacity: 0.5;
-  pointer-events: none;
+.left {
+  flex-shrink: 0;
+  margin-left: calc(var(--switch-container-width) * -1 + 2rem);
+  color: rgb(48, 48, 48);
 }
-
-/* Toggle Button Shape */
-
-.toggle__button .toggle__switch::after,
-.toggle__button .toggle__switch::before {
-  content: "";
-  position: absolute;
-  display: block;
-  height: 18px;
-  width: 18px;
-  border-radius: 50%;
-  left: 0;
-  top: -3px;
-  transform: translateX(0);
-  transition: all 0.25s cubic-bezier(0.5, -0.6, 0.5, 1.6);
+.leftWhite {
+  flex-shrink: 0;
+  margin-left: calc(var(--switch-container-width) * -1 + 2rem);
+  color: white;
 }
-
-.toggle__button .toggle__switch {
-  display: inline-block;
-  height: 12px;
-  border-radius: 6px;
-  width: 40px;
-  background: #b6caf7;
-  box-shadow: inset 0 0 1px #b6caf7;
+.right {
+  flex-shrink: 0;
+  margin-left: 3rem;
+  color: rgb(48, 48, 48);
+}
+.rightWhite {
+  flex-shrink: 0;
+  margin-left: 3rem;
+  color: white;
+}
+/* Visually hide the checkbox input */
+.input {
+  /* position: relative; */
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+.switch {
+  --switch-container-size: 80px;
+  --switch-size: calc(var(--switch-container-size) / 2);
+  --blue: #4760f3;
+  --dark-blue: #3a4fca;
+  /* Vertically center the inner circle */
+  display: flex;
+  align-items: center;
   position: relative;
-  margin-left: 10px;
-  transition: all 0.25s;
+  height: var(--switch-size);
+  flex-basis: var(--switch-container-width);
+  z-index: -1;
+  /* Make the container element rounded */
+  border-radius: var(--switch-size);
+  background-color: white;
+  /* In case the label gets really long, the toggle shouldn't shrink. */
+  flex-shrink: 0;
+  border: 2px solid var(--dark-blue);
+  transition: background-color 0.25s ease-in-out;
 }
-
-/* Toggle Left */
-.toggle__button .toggle__switch::after {
-  background: #6791f0;
-  box-shadow: 0 0 1px #666;
+.switch::before {
+  content: "";
+  /* position: absolute; */
+  height: calc(var(--switch-size) - 4px);
+  width: calc(var(--switch-container-width) / 2);
+  /* Make the inner circle fully rounded */
+  border-radius: var(--switch-size);
+  background-color: var(--blue);
+  border: 2px solid var(--dark-blue);
+  transition: transform 0.375s ease-in-out;
 }
-
-/*
-.toggle__button .toggle__switch::before {
-  background: #6791f0;
-  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);
-  opacity: 0;
-} 
-*/
-
-/* Toggle Right */
-.active .toggle__switch {
-  background: #adedcb;
-  box-shadow: inset 0 0 1px #adedcb;
-}
-
-.active .toggle__switch::after,
-.active .toggle__switch::before {
-  transform: translateX(40px - 18px);
-}
-
-.active .toggle__switch::after {
-  left: 23px;
-  background: #53b883;
-  box-shadow: 0 0 1px #53b883;
+.input:checked + .switch::before {
+  /* Move the inner circle to the right */
+  transform: translateX(calc(var(--switch-container-width) / 2));
 }
 </style>

--- a/frontend/src/components/AppToggleExternalText.vue
+++ b/frontend/src/components/AppToggleExternalText.vue
@@ -1,123 +1,157 @@
 <template>
   <label
-    class="container"
-    :style="'--switch-container-width: 20rem'"
-    @click="update"
+    :for="id + '_button'"
+    :class="{ active: isActive }"
+    class="toggle__button"
   >
+    <span class="toggle__label">{{ toggleLeftText }}</span>
+
     <input
-      v-bind="$attrs"
-      class="input"
       type="checkbox"
-      :checked="checked"
-      @change="$emit('update:checked', $event.target.checked)"
+      :disabled="disabled"
+      :id="id + '_button'"
+      v-model="checkedValue"
     />
-    <span class="switch"></span>
-    <span v-bind:class="{ leftWhite: !checked, left: checked }">{{
-      leftText
-    }}</span>
-    <span v-bind:class="{ right: !checked, rightWhite: checked }">{{
-      rightText
-    }}</span>
+
+    <span class="toggle__switch"></span>
+
+    <span class="toggle__label">{{ toggleRightText }}</span>
   </label>
 </template>
 
 <script>
 export default {
-  name: "Switch",
   props: {
-    leftText: {
-      type: String,
-      required: true
-    },
-    rightText: {
-      type: String,
-      required: true
-    },
-    checked: {
+    /* Boolean dictates the disabled state of toggle */
+    disabled: {
       type: Boolean,
-      required: true
+      default: false
+    },
+    /* Text of the false or left state */
+    toggleLeftText: {
+      type: String,
+      default: "«Left«"
+    },
+    /* Text of the false or right state */
+    toggleRightText: {
+      type: String,
+      default: "»Right»"
+    },
+    id: {
+      type: String,
+      default: "primary"
+    },
+    /* Default state of the toggle (false is left) */
+    defaultState: {
+      type: Boolean,
+      default: false
     }
   },
-  methods: {
-    update() {
-      this.$emit("update");
+  data() {
+    return {
+      currentToggleState: this.defaultState
+    };
+  },
+  watch: {
+    defaultState: function defaultState() {
+      this.currentToggleState = Boolean(this.defaultState);
+    }
+  },
+  computed: {
+    isActive() {
+      return this.currentToggleState;
+    },
+    /* Returns disabled / left text */
+    disabledText() {
+      return this.toggledLeftText;
+    },
+    /* Returns enabled / right text */
+    enabledText() {
+      return this.toggledRightText;
+    },
+    checkedValue: {
+      get() {
+        return this.currentToggleState;
+      },
+      set(newValue) {
+        this.currentToggleState = newValue;
+        this.$emit("change", newValue);
+      }
     }
   }
 };
 </script>
 
 <style scoped>
-.container {
-  width: var(--switch-container-width);
+/* TODO: Clean up styling */
+/* TODO: Grey out disabled toggle */
+/* TODO: Create constants for the accent colours for ease of modification */
+.toggle__label {
+  padding: 0 1rem;
+  font-size: 0.875em;
+}
+/* Hide Checkbox */
+.toggle__button input[type="checkbox"] {
+  display: none;
+}
+.toggle__button {
+  vertical-align: middle;
+  user-select: none;
   cursor: pointer;
-  display: flex;
-  align-items: center;
 }
-.left {
-  flex-shrink: 0;
-  margin-left: calc(var(--switch-container-width) * -1 + 2rem);
-  color: rgb(48, 48, 48);
+.toggle__button button[disabled] {
+  opacity: 0.5;
+  pointer-events: none;
 }
-.leftWhite {
-  flex-shrink: 0;
-  margin-left: calc(var(--switch-container-width) * -1 + 2rem);
-  color: white;
-}
-.right {
-  flex-shrink: 0;
-  margin-left: 3rem;
-  color: rgb(48, 48, 48);
-}
-.rightWhite {
-  flex-shrink: 0;
-  margin-left: 3rem;
-  color: white;
-}
-/* Visually hide the checkbox input */
-.input {
-  /* position: relative; */
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-.switch {
-  --switch-container-size: 80px;
-  --switch-size: calc(var(--switch-container-size) / 2);
-  --blue: #4760f3;
-  --dark-blue: #3a4fca;
-  /* Vertically center the inner circle */
-  display: flex;
-  align-items: center;
-  position: relative;
-  height: var(--switch-size);
-  flex-basis: var(--switch-container-width);
-  z-index: -1;
-  /* Make the container element rounded */
-  border-radius: var(--switch-size);
-  background-color: white;
-  /* In case the label gets really long, the toggle shouldn't shrink. */
-  flex-shrink: 0;
-  border: 2px solid var(--dark-blue);
-  transition: background-color 0.25s ease-in-out;
-}
-.switch::before {
+/* Toggle Button Shape */
+.toggle__button .toggle__switch::after,
+.toggle__button .toggle__switch::before {
   content: "";
-  /* position: absolute; */
-  height: calc(var(--switch-size) - 4px);
-  width: calc(var(--switch-container-width) / 2);
-  /* Make the inner circle fully rounded */
-  border-radius: var(--switch-size);
-  background-color: var(--blue);
-  border: 2px solid var(--dark-blue);
-  transition: transform 0.375s ease-in-out;
+  position: absolute;
+  display: block;
+  height: 18px;
+  width: 18px;
+  border-radius: 50%;
+  left: 0;
+  top: -3px;
+  transform: translateX(0);
+  transition: all 0.25s cubic-bezier(0.5, -0.6, 0.5, 1.6);
 }
-.input:checked + .switch::before {
-  /* Move the inner circle to the right */
-  transform: translateX(calc(var(--switch-container-width) / 2));
+.toggle__button .toggle__switch {
+  display: inline-block;
+  height: 12px;
+  border-radius: 6px;
+  width: 40px;
+  background: #b6caf7;
+  box-shadow: inset 0 0 1px #b6caf7;
+  position: relative;
+  margin-left: 10px;
+  transition: all 0.25s;
+}
+/* Toggle Left */
+.toggle__button .toggle__switch::after {
+  background: #6791f0;
+  box-shadow: 0 0 1px #666;
+}
+/*
+.toggle__button .toggle__switch::before {
+  background: #6791f0;
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);
+  opacity: 0;
+} 
+*/
+/* Toggle Right */
+.active .toggle__switch {
+  background: #adedcb;
+  box-shadow: inset 0 0 1px #adedcb;
+}
+.active .toggle__switch::after,
+.active .toggle__switch::before {
+  transform: translateX(40px - 18px);
+}
+.active .toggle__switch::after {
+  left: 23px;
+  background: #53b883;
+  box-shadow: 0 0 1px #53b883;
 }
 </style>

--- a/frontend/src/components/Calendar.vue
+++ b/frontend/src/components/Calendar.vue
@@ -119,7 +119,8 @@ export default defineComponent({
 .times {
   flex: 1;
   text-align: center;
-  /*margin-right: 1rem;*/
+  margin-top: 2rem;
+  margin-left: 2rem;
 }
 
 .time {
@@ -131,5 +132,8 @@ export default defineComponent({
   display: flex;
   flex: 12;
   justify-content: space-between;
+  margin-top: 2rem;
+  margin-right: 2rem;
+  margin-bottom: 2rem;
 }
 </style>

--- a/frontend/src/views/Event.vue
+++ b/frontend/src/views/Event.vue
@@ -21,7 +21,7 @@
         <div class="timezone">(Time displayed in {{ timezone }})</div>
 
         <section class="toggle-buttons">
-          <AppToggleExternalText
+          <AppToggleInternalText
             v-model:checked="displayGroupAvail"
             @update="switchCalendar()"
             leftText="My Availability"
@@ -57,7 +57,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import AppButton from "@/components/AppButton.vue";
-import AppToggleExternalText from "@/components/AppToggleExternalText.vue";
+import AppToggleInternalText from "@/components/AppToggleInternalText.vue";
 import Calendar from "@/components/Calendar.vue";
 import EventRespondents from "@/components/EventRespondents.vue";
 import AppNotification from "@/components/AppNotification.vue";
@@ -69,7 +69,7 @@ export default defineComponent({
   components: {
     AppButton,
     AppNotification,
-    AppToggleExternalText,
+    AppToggleInternalText,
     Calendar,
     EventRespondents
   },

--- a/frontend/src/views/Event.vue
+++ b/frontend/src/views/Event.vue
@@ -22,8 +22,10 @@
 
         <section class="toggle-buttons">
           <AppToggleExternalText
-            toggleLeftText="My Availability"
-            toggleRightText="Group Availability"
+            v-model:checked="displayGroupAvail"
+            @update="switchCalendar()"
+            leftText="My Availability"
+            rightText="Group Availability"
           />
           <div class="buttons">
             <AppButton
@@ -90,6 +92,7 @@ export default defineComponent({
       calendar: {
         blocks: []
       },
+      displayGroupAvail: true,
       notificationText: "Some Notification",
       notificationVisible: false
     };
@@ -107,7 +110,7 @@ export default defineComponent({
   methods: {
     handleSave() {
       // save the calendar
-      //alert("handleSave is called");
+      // alert("handleSave is called");
       // and show notification with "Availability saved!"
       this.notificationVisible = true;
       this.notificationText = "Availability saved!";
@@ -115,11 +118,15 @@ export default defineComponent({
     },
     copyLink() {
       // copy the link to the event
-      //alert("copyLink is called");
+      // alert("copyLink is called");
       // and show notification with "Event link copied to clipboard!"
       this.notificationVisible = true;
       this.notificationText = "Event link copied to clipboard!";
       setTimeout(() => (this.notificationVisible = false), 5000);
+    },
+    switchCalendar() {
+      // method to switch between user's calendar and group calendar
+      console.log("calendar switched");
     }
   }
 });
@@ -160,6 +167,11 @@ export default defineComponent({
   justify-content: space-around;
   align-items: center;
   margin: 0 1rem;
+}
+
+.buttons {
+  display: flex;
+  flex-shrink: 0;
 }
 
 .btn {


### PR DESCRIPTION
## Overview ⚙️

> Updated events view page for CSS that adheres to designs and better responsiveness

## Change Summary

* AppToggleExternalText will now call an update function when clicked so that Events.vue can switch between user calendar and group calendar (still need to write the function)
* AppToggleExternalText now adheres to designs
* 'Save Response' and 'Copy Event Link' buttons no longer stack on top of each other when window is shrunk
* Widened Calendar margins for better layout

## Screenshots

<img width="1353" alt="Screen Shot 2020-11-20 at 4 51 08 PM" src="https://user-images.githubusercontent.com/52767104/99862964-bb055900-2b50-11eb-91a6-f78925fcf6fc.png">


## Related Issues ⚠️

> Put any issue that this PR addresses here. Make sure you use a [closing keyword](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) so GitHub knows to link the issue(s).

Closes #55 
