### PR TITLE
Fix update textinput component

### DIFF
--- a/src/common/TextInput.vue
+++ b/src/common/TextInput.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="input-container">
-    <component :is="currInputComponent" v-bind="$attrs" />
+    <component
+      :is="currInputComponent"
+      v-bind="$attrs"
+      :style="resizeAttribute"
+    />
     <div class="suffix">
       <slot name="suffix"></slot>
     </div>
@@ -8,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed } from "vue";
+import { defineComponent, computed } from "vue";
 import TextInputInput from "@/common/TextInputInput.vue";
 import TextInputTextarea from "@/common/TextInputTextarea.vue";
 
@@ -21,7 +25,8 @@ export default defineComponent({
   },
 
   props: {
-    type: { type: String, required: true, default: "input" }
+    type: { type: String, required: true },
+    resize: { type: String, default: "" }
   },
 
   setup(props) {
@@ -29,7 +34,9 @@ export default defineComponent({
       props.type === "textarea" ? TextInputTextarea : TextInputInput
     );
 
-    return { currInputComponent };
+    const resizeAttribute = computed(() => `resize: ${props.resize}`);
+
+    return { currInputComponent, resizeAttribute };
   }
 });
 </script>
@@ -38,11 +45,9 @@ export default defineComponent({
 input,
 textarea {
   width: 100%;
-  padding: 0.5rem;
-  border: 1px solid rgb(240, 243, 245);
+  border: 1px solid var(--color-border);
   border-radius: 5px;
-  background: rgb(255, 255, 255);
-  resize: vertical;
+  padding: 0.5rem;
 }
 
 .input-container {
@@ -52,7 +57,7 @@ textarea {
 
 .suffix {
   position: absolute;
-  top: 50%;
+  top: 1.5rem;
   right: 0.5rem;
   transform: translateY(-50%);
 }

--- a/src/common/TextInput.vue
+++ b/src/common/TextInput.vue
@@ -25,7 +25,7 @@ export default defineComponent({
   },
 
   props: {
-    type: { type: String, required: true },
+    type: { type: String, default: "input" },
     resize: { type: String, default: "" }
   },
 

--- a/src/event/views/CreateEventPage.vue
+++ b/src/event/views/CreateEventPage.vue
@@ -59,7 +59,6 @@
         <TextInput
           v-model="eventTitle"
           class="textinput"
-          type="input"
           placeholder="My Awesome Event"
           required
         />

--- a/src/event/views/CreateEventPage.vue
+++ b/src/event/views/CreateEventPage.vue
@@ -81,8 +81,8 @@
             class="textarea"
             type="textarea"
             placeholder="Enter Description"
-            resize="none"
             autofocus
+            resize="vertical"
           >
             <template #suffix>
               <button

--- a/src/user/components/LoginPage.vue
+++ b/src/user/components/LoginPage.vue
@@ -3,9 +3,9 @@
     <div class="heading">Log In</div>
     <div class="p1">
       <p>Username/Email:</p>
-      <input v-model="username" class="input" />
+      <TextInput v-model="username" />
       <p>Password:</p>
-      <input v-model="password" class="input" />
+      <TextInput v-model="password" />
     </div>
     <div class="button">
       <AppButton text="Log in" @update="logIn()" />
@@ -22,10 +22,12 @@ import { defineComponent } from "vue";
 import client from "../client";
 import AppButton from "@/common/AppButton.vue";
 import router from "@/router";
+import TextInput from "@/common/TextInput.vue";
 
 export default defineComponent({
   components: {
-    AppButton
+    AppButton,
+    TextInput
   },
   data() {
     return {


### PR DESCRIPTION
## Overview ⚙️
Updated `TextInput.vue` and instances of `<TextInput />`

## Change Summary
- remove unused import
- support `resize` prop on `<TextInput /> b/c it can't be done on via CSS for that component's usage
- update `type` prop to not be required and default to `<input>`
- update styling to use `App.vue` CSS variable themes
- fix icon suffix positioning (especially for vertical resizing textarea)
- update all instances of input to use `<TextInput />`

## Screenshots
![image](https://user-images.githubusercontent.com/24283779/110898209-a2fa4680-82b3-11eb-9e28-2568cb952e7d.png)
![image](https://user-images.githubusercontent.com/24283779/110898160-8e1db300-82b3-11eb-9db8-8976e48432e5.png)

