### PR TITLE
fix TextInput to work with v-model

### DIFF
--- a/src/common/TextInputInput.vue
+++ b/src/common/TextInputInput.vue
@@ -1,11 +1,24 @@
 <template>
-  <input type="text" />
+  <input
+    type="text"
+    :value="modelValue"
+    @input="$emit('update:modelValue', $event.target.value)"
+  />
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
 
 export default defineComponent({
-  name: "TextInputInput"
+  name: "TextInputInput",
+
+  // Allow for v-model to work in custom component TextInput
+  props: {
+    modelValue: {
+      type: String,
+      required: true
+    }
+  },
+  emits: ["update:modelValue"]
 });
 </script>

--- a/src/common/TextInputTextarea.vue
+++ b/src/common/TextInputTextarea.vue
@@ -1,11 +1,23 @@
 <template>
-  <textarea></textarea>
+  <textarea
+    :value="modelValue"
+    @input="$emit('update:modelValue', $event.target.value)"
+  />
 </template>
 
 <script lang="ts">
 import { defineComponent } from "vue";
 
 export default defineComponent({
-  name: "TextInputTextarea"
+  name: "TextInputTextarea",
+
+  // Allow for v-model to work in custom component TextInput
+  props: {
+    modelValue: {
+      type: String,
+      required: true
+    }
+  },
+  emits: ["update:modelValue"]
 });
 </script>


### PR DESCRIPTION
## Overview ⚙️

Fix `TextInputInput.vue` and `TextInputTextarea.vue` to allow `v-model` to work properly

Reference [Vue 3 Docs](https://v3.vuejs.org/guide/component-basics.html#using-v-model-on-components)

**_Note_**
Not sure if the `modelValue` prop should be required but it should still work regardless.
Alternative code:
```javascript
props: {
    modelValue: {
      type: String,
      default: ""
    }
  },
```