### PR TITLE
feat: allow logged in users to participate in events

### DIFF
--- a/src/calendar/components/Calendar.vue
+++ b/src/calendar/components/Calendar.vue
@@ -13,6 +13,7 @@
         :date="date"
         :times="times"
         :blocks="blocks"
+        :current-user="currentUser"
         @update:blocks="updateCalendar"
       />
     </div>
@@ -54,6 +55,10 @@ export default defineComponent({
       required: true
     },
     endTime: {
+      type: String,
+      required: true
+    },
+    currentUser: {
       type: String,
       required: true
     }

--- a/src/calendar/components/Calendar.vue
+++ b/src/calendar/components/Calendar.vue
@@ -13,6 +13,7 @@
         :date="date"
         :times="times"
         :blocks="blocks"
+        :respondents="respondents"
         :current-user="currentUser"
         @update:blocks="updateCalendar"
       />
@@ -65,6 +66,13 @@ export default defineComponent({
   },
   emits: ["update:calendar"],
   computed: {
+    respondents() {
+      const respondents = new Set();
+      for (const block of this.calendar.blocks) {
+        block.availableUsers.forEach(user => respondents.add(user));
+      }
+      return respondents.size;
+    },
     days(): Day[] {
       return eachDayOfInterval({
         start: this.start,

--- a/src/calendar/components/CalendarDay.vue
+++ b/src/calendar/components/CalendarDay.vue
@@ -4,6 +4,7 @@
     <div
       v-for="time in times"
       :key="`${dateText}-${time}`"
+      :style="{ '--opacity': getOpacity(time) }"
       :class="['block', { selected: isActive(time) }]"
       @touchstart="handleMouseDown(time, $event)"
       @mousedown="handleMouseDown(time, $event)"
@@ -34,6 +35,10 @@ export default defineComponent({
     },
     blocks: {
       type: Object as PropType<Array<Block>>,
+      required: true
+    },
+    respondents: {
+      type: Number,
       required: true
     },
     currentUser: {
@@ -78,6 +83,13 @@ export default defineComponent({
     },
     getBlock(time: Time) {
       return this.blocks.find(block => this.equalsBlock(time, block));
+    },
+    getOpacity(time: Time) {
+      const block = this.getBlock(time);
+      if (block) {
+        return block.availableUsers.length / this.respondents;
+      }
+      return 1;
     },
     isActive(time: Time) {
       return this.getBlock(time) !== undefined;
@@ -145,5 +157,6 @@ export default defineComponent({
 
 .selected {
   background: rgba(143, 192, 198, 1);
+  opacity: var(--opacity);
 }
 </style>

--- a/src/event/views/EventPage.vue
+++ b/src/event/views/EventPage.vue
@@ -60,6 +60,7 @@
 //FIXME: Layout
 //FIXME: Multiple timers clashing in AppSnackbar notifications
 import { computed, defineComponent, watch, ref, reactive, toRefs } from "vue";
+import { useRouter } from "vue-router";
 import AppButton from "@/common/AppButton.vue";
 import AppToggleInternalText from "@/common/AppToggleInternalText.vue";
 import AppSnackbar from "@/common/AppSnackbar.vue";
@@ -69,7 +70,6 @@ import { useUser } from "@/user/hooks";
 import EventRespondents from "../components/EventRespondents.vue";
 import client from "../client";
 import { useEvent } from "../hooks";
-import { useRouter } from "vue-router";
 
 export default defineComponent({
   components: {
@@ -96,6 +96,9 @@ export default defineComponent({
      * We want to block users from accessing this page if they're not logged in, so
      * we'll redirect them as soon as the user is fetched and we know they're not
      * logged in.
+     *
+     * When redirecting, we add the link to the current event so the login page
+     * knows where to redirect once logged in.
      */
     watch(isLoading, loading => {
       if (!loading && !user.value) {

--- a/src/event/views/EventPage.vue
+++ b/src/event/views/EventPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!event">Loading</div>
+  <div v-if="!event || isLoading">Loading</div>
   <div v-else class="page-container">
     <header>
       <h5>{{ event.title }}</h5>
@@ -14,6 +14,7 @@
           class="calendar"
           :start-time="start"
           :end-time="end"
+          :current-user="user.uid"
         />
 
         <AppSnackbar
@@ -64,9 +65,11 @@ import AppToggleInternalText from "@/common/AppToggleInternalText.vue";
 import AppSnackbar from "@/common/AppSnackbar.vue";
 import Calendar from "@/calendar/components/Calendar.vue";
 import { Calendar as CalendarType } from "@/calendar/client";
+import { useUser } from "@/user/hooks";
 import EventRespondents from "../components/EventRespondents.vue";
 import client from "../client";
 import { useEvent } from "../hooks";
+import { useRouter } from "vue-router";
 
 export default defineComponent({
   components: {
@@ -83,6 +86,28 @@ export default defineComponent({
     }
   },
   setup(props) {
+    const { user, isLoading } = useUser();
+    const router = useRouter();
+
+    /**
+     * The user is fetched asynchronously, so initially it's going to be null
+     * regardless if the user is logged in or not.
+     *
+     * We want to block users from accessing this page if they're not logged in, so
+     * we'll redirect them as soon as the user is fetched and we know they're not
+     * logged in.
+     */
+    watch(isLoading, loading => {
+      if (!loading && !user.value) {
+        router.replace({
+          path: "/login",
+          query: {
+            redirectTo: router.currentRoute.value.path
+          }
+        });
+      }
+    });
+
     // state
     const state = reactive({
       displayGroupAvail: false,
@@ -113,6 +138,8 @@ export default defineComponent({
       start,
       end,
       calendar,
+      user,
+      isLoading,
       ...toRefs(state),
       async handleSave() {
         // save the calendar

--- a/src/user/client.ts
+++ b/src/user/client.ts
@@ -3,7 +3,7 @@ import { app, db } from "@/db";
 import firebase from "firebase/app";
 import "firebase/auth";
 
-const Auth = app.auth();
+export const Auth = app.auth();
 
 export interface User {
   username: string;
@@ -21,7 +21,7 @@ function saveUserToDb(user: User) {
     });
 }
 
-function createUserObject(user: firebase.User) {
+export function createUserObject(user: firebase.User) {
   const { uid, email } = user;
   const newUser = {
     uid: uid,

--- a/src/user/components/LoginPage.vue
+++ b/src/user/components/LoginPage.vue
@@ -17,11 +17,9 @@
 </template>
 
 <script lang="ts">
-import firebase from "firebase/app";
 import { defineComponent } from "vue";
 import client from "../client";
 import AppButton from "@/common/AppButton.vue";
-import router from "@/router";
 import TextInput from "@/common/TextInput.vue";
 
 export default defineComponent({
@@ -35,15 +33,21 @@ export default defineComponent({
       password: ""
     };
   },
+  computed: {
+    redirectTo() {
+      const redirectTo = this.$route.query.redirectTo as string;
+      return redirectTo || "/";
+    }
+  },
   methods: {
     async logIn() {
       client.login(this.username, this.password).then(() => {
-        this.$router.push("/");
+        this.$router.push(this.redirectTo);
       });
     },
     logInViaGoogle() {
       client.googleLogin().then(() => {
-        this.$router.push("/");
+        this.$router.push(this.redirectTo);
       });
     }
   }

--- a/src/user/hooks.ts
+++ b/src/user/hooks.ts
@@ -1,0 +1,26 @@
+import { ref } from "vue";
+import { Auth, User, createUserObject } from "./client";
+
+/**
+ * Returns a reactive user instance that changes when the user logs in and out.
+ *
+ * The user information is fetched asynchronously, so initially it will always be
+ * null regardless if the user is logged in or not. To accomodate for this, we also
+ * return an "isLoading" state that determines whether we're still retrieving the
+ * user's information.
+ *
+ * @returns a reative user object and whether the user is still being fetched
+ */
+export function useUser() {
+  const user = ref<User | null>(null);
+  const isLoading = ref(true);
+
+  Auth.onAuthStateChanged(firebaseUser => {
+    isLoading.value = false;
+    if (firebaseUser) {
+      user.value = createUserObject(firebaseUser);
+    }
+  });
+
+  return { isLoading, user };
+}


### PR DESCRIPTION
## Overview ⚙️

- Allow logged in users to participate in events
- Redirect not logged in users to the login screen when they visit an event

## Change Summary

- `Calendar.vue` and `CalendarDay.vue` — update the Calendar implementations to accept a `currentUser` and `respondents` props. These props are used for the logic in creating and updating existing blocks.
- `CalendarDay.vue` — update the `toggle` block logic to check the current user first. This limits the user to only updating blocks that they belong to.
- `EventPage.vue` — update the Event page to check if the user is logged in or not. If not, redirect the user to the login page.
- `user/client.ts` — added the Auth app and the `createUserObject` helper function to the list of exports to be used in the custom hook.
- `user/hooks.ts` — added a `useUser` hook that returns a reactive user object, meaning it automatically changes when the user logs in and out.
- `LoginPage.vue` — updated the implementation to support redirects using a `redirectTo` query. This allows users to be redirected back to the event page after they log in.
  - An example url with a redirect link looks like `/login?redirectTo=/event/abcdef`

## Screenshots

Users getting redirected:

https://user-images.githubusercontent.com/31267630/111890948-88a72380-89ab-11eb-8c7a-3fa7bd972363.mp4

Two different users participating in an event:

https://user-images.githubusercontent.com/31267630/111890958-9492e580-89ab-11eb-999c-894de2c90405.mp4

## Related Issues ⚠️

- Doesn't work in Incognito mode for some reason; maybe some Firebase issue.
