### PR TITLE
fix: hide input box for chrome AND firefox

### DIFF
--- a/src/common/AppToggle.vue
+++ b/src/common/AppToggle.vue
@@ -60,13 +60,7 @@ export default {
 
 /* Visually hide the checkbox input */
 .input {
-  width: 0;
-  height: 0;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  white-space: nowrap;
-  border-width: 0;
+  display: none;
 }
 
 .switch {


### PR DESCRIPTION
## Overview ⚙️

Fix toggle to hide checkbox for Firefox and not just Chrome

## Change Summary
- fix with just `display: none`

## Screenshots
![image](https://user-images.githubusercontent.com/24283779/114276900-9285da80-99dd-11eb-9d67-06e7afdeb2a1.png)
_Removed this_
